### PR TITLE
index.html: change docs link for service bound to the app

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -167,7 +167,7 @@
               <!-- service bound to the app -->
               <div th:if="${cfservicename != null}">
                 <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 ptl txt-r type-ellipsis">
-                  <a href='http://docs.cloudfoundry.org/buildpacks/java/spring-service-bindings.html' target='_blank' class='type-accent-4'>
+                  <a href='http://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections/spring-service-bindings.html' target='_blank' class='type-accent-4'>
                     <span class="small">Configuring Services</span><span class="fa fa-icon fa-external-link plm txt-m small"></span>
                   </a>
                 </div>


### PR DESCRIPTION
`http://docs.cloudfoundry.org/buildpacks/java/spring-service-bindings.html` no longer exists, I believe the correct link is `http://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections/spring-service-bindings.html`