### PR TITLE
Rename cf-spring to cf-demo

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: cf-spring
+- name: cf-demo
   memory: 768M
   instances: 1
   random-route: true


### PR DESCRIPTION
When people push this app as part of their free trial or first tutorial
with Pivotal Web Services, there has started to be a high probability
that the random route will collide. This renames the sample app to
change the prefix so of the randomly chosen hostname so that the routes
will not collide.

We may also do work in the CLI to increase the space of random routes
that are chosen, but in the meantime this is a very simple way to fix
the problem.