### PR TITLE
Corrected Configuring Service Connections for Spring

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -167,7 +167,7 @@
               <!-- service bound to the app -->
               <div th:if="${cfservicename != null}">
                 <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6 ptl txt-r type-ellipsis">
-                  <a href='http://docs.cloudfoundry.org/buildpacks/java/spring-service-bindings.html' target='_blank' class='type-accent-4'>
+                  <a href='http://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections/spring-service-bindings.html' target='_blank' class='type-accent-4'>
                     <span class="small">Configuring Services</span><span class="fa fa-icon fa-external-link plm txt-m small"></span>
                   </a>
                 </div>


### PR DESCRIPTION
Changed the URL to the correct one: http://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections/spring-service-bindings.html